### PR TITLE
Feat DataObject/DataComponentBase 형식의 데이터 구조 업데이트.

### DIFF
--- a/Data/Script.Test/UnitTests.cs
+++ b/Data/Script.Test/UnitTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace BaeknothingLib.Data.Test;
+
+public class UnitTests
+{
+    class TestComponent : DataComponentBase
+    {
+        public static string Key => "TestComponent";
+        public int Value { get; private set; } = 0;
+        public void SetValue(int value) => this.Value = value;
+
+        public override string GetKey()
+        {
+            return Key;
+        }
+
+        public override Dictionary<string, object> ToMap()
+        {
+            return new Dictionary<string, object> { { nameof(Value), Value } };
+        }
+
+        protected override void FromMapInternal(Dictionary<object, object> map)
+        {
+            if (map.TryGetValue(nameof(Value), out var value))
+            {
+                Value = (int)value;
+            }
+        }
+
+        public override string Print()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+
+
+    [SetUp]
+    public void Setup()
+    {
+
+    }
+
+    [Test]
+    public void Test_DataObject_Initialization()
+    {
+        var components = new List<DataComponentBase> { new TestComponent() };
+        var DataObject = new DataObject(components);
+        Assert.Multiple(() =>
+        {
+            Assert.That(DataObject.IsInitialized, Is.True);
+            Assert.That(DataObject.GetComponent<TestComponent>(), Is.Not.Null);
+            Assert.That(DataObject.ToMap(), Has.Count.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Test_DataObject_Component()
+    {
+        var components = new List<DataComponentBase> { new TestComponent() };
+        var DataObject = new DataObject(components);
+        var testComponent = DataObject.GetComponent<TestComponent>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(DataObject.IsInitialized, Is.True);
+
+            Assert.That(testComponent, Is.Not.Null);
+            Assert.That(testComponent?.GetKey(), Is.EqualTo(TestComponent.Key));
+            Assert.That(testComponent?.ToMap(), Has.Count.EqualTo(1).And.Contains(new KeyValuePair<string, object>(nameof(TestComponent.Value), 0)));
+            testComponent?.SetValue(10);
+            Assert.That(testComponent?.ToMap(), Has.Count.EqualTo(1).And.Contains(new KeyValuePair<string, object>(nameof(TestComponent.Value), 10)));
+
+            DataObject.FromMap(new Dictionary<object, object> { { TestComponent.Key, new Dictionary<object, object> { { nameof(TestComponent.Value), 20 } } } });
+            Assert.That(testComponent?.Value, Is.EqualTo(20));
+        });
+    }
+}

--- a/Data/Script/DataBase.cs
+++ b/Data/Script/DataBase.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Text;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BaeknothingLib.Data;
+
+public interface IDataObject
+{
+    public bool IsInitialized { get; }
+    public T? GetComponent<T>() where T : DataComponentBase;
+
+    public Dictionary<string, object> ToMap();
+    public void FromMap(Dictionary<object, object> map);
+    public string Print(bool printAll);
+}
+
+public class DataObject : IDataObject
+{
+    public bool IsInitialized { get; private set; } = false;
+    private readonly Dictionary<string, DataComponentBase> _components = [];
+
+    public DataObject(List<DataComponentBase> components)
+    {
+        Debug.Assert(components != null, "Components is null");
+
+        components.ForEach(component => _components[component.GetKey()] = component);
+        IsInitialized = true;
+    }
+
+    public T? GetComponent<T>() where T : DataComponentBase
+    {
+        Debug.Assert(IsInitialized, "Character is not initialized");
+
+        var key = typeof(T).Name;
+        if (_components.TryGetValue(key, out var component))
+            return component as T;
+
+        return null;
+    }
+
+    public Dictionary<string, object> ToMap()
+    {
+        Debug.Assert(IsInitialized, "Character is not initialized");
+
+        var map = new Dictionary<string, object>();
+        foreach (var component in _components)
+        {
+            map[component.Key] = component.Value.ToMap();
+        }
+
+        return map;
+    }
+
+    public void FromMap(Dictionary<object, object> map)
+    {
+        Debug.Assert(IsInitialized, "DataObject is not initialized");
+        Debug.Assert(Utility.CheckIsValidMap(map), "Map is not valid");
+
+        var stringMap = Utility.ConvertMapKey_ObjectToString(map);
+
+        foreach (var key in stringMap.Keys)
+        {
+            if (_components.TryGetValue(key, out var component) &&
+                stringMap[key] is Dictionary<object, object> mapValue)
+            {
+                component.FromMap(mapValue);
+            }
+            else
+            {
+                Debug.Assert(false, $"Component {key} not found or map value is not valid");
+            }
+        }
+    }
+
+
+    public string Print(bool printAll)
+    {
+        Debug.Assert(IsInitialized, "Character is not initialized");
+
+        var stringBuilder = new StringBuilder();
+        stringBuilder.Append("Character:\n");
+        stringBuilder.Append("Keys : ");
+        stringBuilder.Append(string.Join(", ", _components.Keys));
+        stringBuilder.Append('\n');
+
+        if (printAll)
+        {
+            stringBuilder.Append("All Data : ");
+            foreach (var component in _components)
+            {
+                stringBuilder.Append(component.Key);
+                stringBuilder.Append(" : ");
+                stringBuilder.Append(component.Value.Print());
+                stringBuilder.Append('\n');
+            }
+        }
+
+        return stringBuilder.ToString();
+    }
+}

--- a/Data/Script/DataComponent.cs
+++ b/Data/Script/DataComponent.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace BaeknothingLib.Data;
+
+public abstract class DataComponentBase
+{
+    public DateTime LastUpdate { get; private set; }
+    public bool IsSaved { get; private set; }
+
+    public void FromMap(Dictionary<object, object> map)
+    {
+        if (!CheckMapIsValid(map))
+            return;
+
+        FromMapInternal(map);
+        LastUpdate = DateTime.Now;
+        IsSaved = false;
+    }
+
+    static bool CheckMapIsValid(Dictionary<object, object> map)
+    {
+        if (map == null)
+            return false;
+
+        foreach (var key in map.Keys)
+        {
+            if (key is not string)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public abstract string GetKey();
+    public abstract Dictionary<string, object> ToMap();
+    abstract protected void FromMapInternal(Dictionary<object, object> map);
+    public abstract string Print();
+}

--- a/Data/Script/Utility.cs
+++ b/Data/Script/Utility.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace BaeknothingLib.Data;
+
+static class Utility
+{
+    public static Dictionary<string, object> ConvertMapKey_ObjectToString(Dictionary<object, object> map)
+    {
+        var newMap = new Dictionary<string, object>();
+        foreach (var key in map.Keys)
+        {
+            if (key is string strKey)
+            {
+                newMap[strKey] = map[key];
+            }
+        }
+
+        return newMap;
+    }
+
+    public static Dictionary<object, object> ConvertMapKey_StringToObject(Dictionary<string, object> map)
+    {
+        var newMap = new Dictionary<object, object>();
+        foreach (var key in map.Keys)
+        {
+            newMap[key] = map[key];
+        }
+
+        return newMap;
+    }
+
+    public static Dictionary<object, object> ConvertObjectToDictionary(object obj)
+    {
+        if (obj is Dictionary<object, object> map)
+        {
+            return map;
+        }
+
+        return [];
+    }
+
+    public static bool CheckIsValidMap(Dictionary<object, object> map)
+    {
+        if (map == null)
+            return false;
+
+        foreach (var key in map.Keys)
+        {
+            if (key is not string)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static T? IsValidComponent<T>(DataComponentBase component) where T : DataComponentBase
+    {
+        if (component is T tComponent)
+        {
+            return tComponent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
JavaScript에서 받은 map데이터를 DataObject로 변환하거나 DataObject를 map(C#에서는 Dictionary<object, object>)변환할 수 있음이 보장되도록하는 DataObject추가. 

DataObject와 DataComponent는 ToMap과 FromMap을 가지고 있으며. DataObject는 자신이 가진 Component를 순회하며 각 Component가 제공하는 ToMap을 Dictionary<string, object>에 담아서 내보낸다 (이 때, string은 각 Component에서 정의한 GetKey)

DataComponent는 추상 클래스이며, 상속받은 뒤 필요로하는 필드를 정의하고 abstract로 정의된 부분을 적절하게 구현해주면 된다. 

이것을 통해, 유연하게 확장 / 수정 가능하며 각 컴포넌트별로 독립된 데이터구조를 만들고자 함. 